### PR TITLE
fix: adds shrink-0 to prevent logo from shrinking on page width resize

### DIFF
--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -2,7 +2,7 @@ import { LogoIcon } from "../../assets/icons/pageIcons";
 
 const Logo = () => {
   return (
-    <div className="flex flex-row justify-start items-center gap-[10px]">
+    <div className="flex shrink-0 flex-row justify-start items-center gap-[10px]">
       <LogoIcon />
       <div className="font-primary text-neutral-0 font-bold text-[22px]">
         Weather Now


### PR DESCRIPTION
## Description
The Logo would shrink as the screen width gets smaller. Adding `shrink-0` to the parent container prevents the shrinking,

Closes #56 