### PR TITLE
feat: create day button component

### DIFF
--- a/src/components/DayButton/DayButton.tsx
+++ b/src/components/DayButton/DayButton.tsx
@@ -1,0 +1,15 @@
+import { ArrowIcon } from "../../assets/icons/pageIcons";
+
+interface IDayButtonProps {
+  currentDay: string;
+}
+
+export const DayButton = ({ currentDay }: IDayButtonProps) => {
+  return (
+    <button className="flex flex-row items-center gap-3 rounded-lg bg-neutral-600 hover:bg-neutral-700 py-2 px-4 text-preset-7 text-neutral-0 cursor-pointer">
+      {currentDay} <ArrowIcon />
+    </button>
+  );
+};
+
+export default DayButton;


### PR DESCRIPTION
## Description
Creates the Day Button component to be used inside the HourlyForecast component.
The weather icon is currently a white circle as a placeholder.

Closes #26 

## Screenshots
<img width="499" height="826" alt="image" src="https://github.com/user-attachments/assets/95cd47e4-b01a-496a-a720-91f043116999" />

<img width="1079" height="818" alt="image" src="https://github.com/user-attachments/assets/e564b294-6fd9-4293-9721-accb44842527" />
