### PR TITLE
fix #85: removed weather variable from props

### DIFF
--- a/src/components/HourCard/HourCard.tsx
+++ b/src/components/HourCard/HourCard.tsx
@@ -4,7 +4,7 @@ interface IHourCardProps {
   weather: string;
 }
 
-export const HourCard = ({ hour, temperature, weather }: IHourCardProps) => {
+export const HourCard = ({ hour, temperature }: IHourCardProps) => {
   return (
     <div className="flex flex-row items-center justify-between bg-neutral-700 rounded-lg h-15 py-[18px] pl-3 pr-4">
       <div className="flex flex-row items-center gap-2">


### PR DESCRIPTION
## Description
Fixing a failed CloudFlare build. Was caused by an unused variable that was passed into the HourCard component. Removed the variable from its props.

Closes #85 
