### PR TITLE
feat #36: create current conditions card component

### DIFF
--- a/src/components/CurrentConditionsCard/CurrentConditionsCard.tsx
+++ b/src/components/CurrentConditionsCard/CurrentConditionsCard.tsx
@@ -1,0 +1,25 @@
+interface ICurrentConditionsCardProps {
+  title: string;
+  value: number;
+  units?: string;
+}
+
+const CurrentConditionsCard = ({
+  title,
+  value,
+  units,
+}: ICurrentConditionsCardProps) => {
+  return (
+    <div className="flex flex-col justify-center items-start p-5 gap-2 bg-neutral-800 rounded-xl border-[1px] border-neutral-600 min-w-[165px] w-full h-[118px]">
+      <div className="text-preset-6 text-neutral-200">{title}</div>
+      <div className="flex flex-row justify-between items-center w-full">
+        <div className="text-preset-3 text-neutral-0">
+          {value} {units}
+        </div>
+        <div className="bg-white size-6 rounded-xl"></div>
+      </div>
+    </div>
+  );
+};
+
+export default CurrentConditionsCard;


### PR DESCRIPTION
## Description
Created the `CurrentConditionsCard` component. This is a reusable component which can display different values depending on passed props. Can pass title, value, and optional units prop.

Closes #36 

## Screenshots
<img width="222" height="158" alt="image" src="https://github.com/user-attachments/assets/3c7ae58d-1852-417d-9fea-515339aad98e" />
