### PR TITLE
fix #95: adds gap between header and button

### DIFF
--- a/src/components/HourlyForecast/HourlyForecast.tsx
+++ b/src/components/HourlyForecast/HourlyForecast.tsx
@@ -50,7 +50,7 @@ const hourlyData = {
 export const HourlyForecast = () => {
   return (
     <div className="flex flex-col gap-4 bg-neutral-800 w-full xl:w-[384px] h-[693px] rounded-[20px] p-6">
-      <div className="flex flex-row justify-between items-center">
+      <div className="flex flex-row gap-2 justify-between items-center">
         <h3 className="text-preset-5 text-neutral-0">Hourly Forecast</h3>
         <DayButton currentDay={hourlyData.currentDay} />
       </div>


### PR DESCRIPTION
## Description
Adds gap between components that appears when screen width gets small enough.

Closes #95 

## Screenshots
Before
<img width="245" height="136" alt="image" src="https://github.com/user-attachments/assets/89244ce3-feb0-47e1-8373-0adff9c2d569" />

After
<img width="263" height="144" alt="image" src="https://github.com/user-attachments/assets/a10be2c1-8dc4-4611-ab18-ff776b2786f3" />

