### PR TITLE
fix #110: background color is attached to selected option

### DIFF
--- a/src/components/UnitsDropdownGroup/UnitsDropdownGroup.tsx
+++ b/src/components/UnitsDropdownGroup/UnitsDropdownGroup.tsx
@@ -25,7 +25,11 @@ const UnitsDropdownGroup = ({
       <div className="flex flex-col gap-1 ">
         {options.map((option, index) => {
           return (
-            <label className="flex justify-between items-center text-preset-7 text-neutral-0 py-2.5 px-2 hover:bg-neutral-600 cursor-pointer rounded-lg">
+            <label
+              className={`${
+                option === selected && "bg-neutral-600"
+              } flex justify-between items-center text-preset-7 text-neutral-0 py-2.5 px-2 hover:bg-neutral-600 cursor-pointer rounded-lg`}
+            >
               {optionsText[index]}
               <input
                 type="radio"


### PR DESCRIPTION
## Description
When an option is selected in the `UnitsDropdownGroup` it will now have a new background to show it's selected, in addition to the existing checkmark.

Closes #110 

## Screenshots
<img width="305" height="557" alt="image" src="https://github.com/user-attachments/assets/4ae22047-a772-4870-96d6-3a73792d868d" />

