### PR TITLE
style #115: fix input layout

### DIFF
--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -5,7 +5,7 @@ import SearchButton from "../SearchButton/SearchButton";
 const SearchBar = () => {
   return (
     <StyledWrapper>
-      <div className="flex flex-row justify-center items-center gap-4 px-0 w-full">
+      <div className="flex flex-col md:flex-row justify-center items-center gap-3 md:gap-4 px-0 w-full">
         <SearchInput />
         <SearchButton />
       </div>

--- a/src/components/SearchButton/SearchButton.tsx
+++ b/src/components/SearchButton/SearchButton.tsx
@@ -1,6 +1,6 @@
 const SearchButton = () => {
   return (
-    <button className="text-preset-5-medium bg-blue-500 hover:bg-blue-700 cursor-pointer rounded-xl text-neutral-0 px-6 py-4">
+    <button className="text-preset-5-medium bg-blue-500 hover:bg-blue-700 cursor-pointer rounded-xl text-neutral-0 px-6 py-4 w-full md:w-[114px]">
       Search
     </button>
   );

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -2,7 +2,7 @@ import { SearchIcon } from "../../assets/icons/pageIcons";
 
 const SearchInput = () => {
   return (
-    <div className="flex flex-row relative w-lg">
+    <div className="flex flex-row relative w-full md:w-lg">
       <SearchIcon className="absolute left-6 top-1/2 -translate-y-1/2" />
       <input
         type="text"


### PR DESCRIPTION
## Description
Fixes the layout of the SearchBar. It is now flex column on smaller screens and the input and button are full width on smaller screens.

Closes #115 

## Screenshots
Desktop
<img width="983" height="150" alt="image" src="https://github.com/user-attachments/assets/65298aa9-253f-4f7b-a9a9-550b254e36f6" />

Mobile
<img width="516" height="210" alt="image" src="https://github.com/user-attachments/assets/497a9c85-7ffe-4d11-bcd3-3b1786a12d2e" />

