### PR TITLE
feat #118: integrate search dropdown

### DIFF
--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -5,7 +5,7 @@ import SearchButton from "../SearchButton/SearchButton";
 const SearchBar = () => {
   return (
     <StyledWrapper>
-      <div className="flex flex-col md:flex-row justify-center items-center gap-3 md:gap-4 px-0 w-full">
+      <div className="relative flex flex-col md:flex-row justify-center items-center gap-3 md:gap-4 px-0 w-full">
         <SearchInput />
         <SearchButton />
       </div>

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -1,14 +1,68 @@
+import { useState, useRef, useEffect } from "react";
+
 import { SearchIcon } from "../../assets/icons/pageIcons";
+import SearchDropdown from "../SearchDropdown/SearchDropdown";
 
 const SearchInput = () => {
+  const [query, setQuery] = useState("");
+  const [searchFocused, setSearchFocused] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const searchDropdownRef = useRef<HTMLDivElement>(null);
+
+  const handleOutsideInputClick = (event: MouseEvent) => {
+    const target = event.target as Node;
+
+    // If clicked inside dropdown
+    if (
+      searchFocused &&
+      searchDropdownRef.current &&
+      searchDropdownRef.current.contains(target)
+    ) {
+      // Does nothing
+      return;
+    }
+    // If outside the input is clicked
+    else if (inputRef.current && !inputRef.current.contains(target)) {
+      setSearchFocused(false);
+    }
+  };
+
+  // Adds/removes event listener for disabling input focus on outside button click.
+  useEffect(() => {
+    const controller = new AbortController();
+
+    document.addEventListener("mousedown", handleOutsideInputClick, {
+      signal: controller.signal,
+    });
+
+    return () => {
+      controller.abort();
+    };
+  });
+
   return (
     <div className="flex flex-row relative w-full md:w-lg">
       <SearchIcon className="absolute left-6 top-1/2 -translate-y-1/2" />
       <input
+        ref={inputRef}
         type="text"
         placeholder="Search for a place..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onFocus={() => setSearchFocused(true)}
+        onClick={() => setSearchFocused(true)}
         className="text-preset-5-medium text-neutral-200 pl-15 bg-neutral-800 hover:bg-neutral-700 py-4 rounded-xl cursor-pointer shrink w-full"
       />
+
+      {query !== "" && searchFocused && (
+        <SearchDropdown
+          searchDropdownRef={searchDropdownRef}
+          setQuery={setQuery}
+          searchFocused={searchFocused}
+          setSearchFocused={setSearchFocused}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Description
Integrates the `SearchDropdown` component into the app's layout. Adds a mousedown listener to control when the dropdown is closed or remains open.

Uses hardcoded location suggestion results. Will be replaced by API fetch results.

Closes #118 

## Screenshots
<img width="1059" height="531" alt="image" src="https://github.com/user-attachments/assets/67956034-6577-44ed-bbc0-6bcb8c803f06" />

<img width="708" height="600" alt="image" src="https://github.com/user-attachments/assets/30ddcfa3-2662-4dfc-b3b8-c18526981676" />

