### PR TITLE
feat #31: create and integrate SettingsContext

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,23 +7,27 @@ import CurrentConditions from "./components/CurrentConditions/CurrentConditions"
 import DailyForecast from "./components/DailyForecast/DailyForecast";
 import StyledWrapper from "./components/StyledWrapper/StyledWrapper";
 
+import { SettingsProvider } from "./context/SettingsContext/SettingsProvider";
+
 function App() {
   return (
-    <div className="bg-neutral-900 pt-6 pb-10 overflow-hidden min-h-screen">
-      <Header />
-      <Hero />
-      <SearchBar />
-      <StyledWrapper>
-        <div className="flex justify-center flex-col xl:flex-row gap-8 pt-8 md:pt-[42px]">
-          <div className="flex flex-col justify-start w-full xl:max-w-[800px]">
-            <MainWeather />
-            <CurrentConditions />
-            <DailyForecast />
+    <SettingsProvider>
+      <div className="bg-neutral-900 pt-6 pb-10 overflow-hidden min-h-screen">
+        <Header />
+        <Hero />
+        <SearchBar />
+        <StyledWrapper>
+          <div className="flex justify-center flex-col xl:flex-row gap-8 pt-8 md:pt-[42px]">
+            <div className="flex flex-col justify-start w-full xl:max-w-[800px]">
+              <MainWeather />
+              <CurrentConditions />
+              <DailyForecast />
+            </div>
+            <HourlyForecast />
           </div>
-          <HourlyForecast />
-        </div>
-      </StyledWrapper>
-    </div>
+        </StyledWrapper>
+      </div>
+    </SettingsProvider>
   );
 }
 

--- a/src/components/UnitsDropdown/UnitsDropdown.tsx
+++ b/src/components/UnitsDropdown/UnitsDropdown.tsx
@@ -1,22 +1,38 @@
-import { useState, useEffect } from "react";
 import type { RefObject } from "react";
 
 import UnitsDropdownGroup from "../UnitsDropdownGroup/UnitsDropdownGroup";
 
+import { useSettingsContext } from "../../hooks/useSettingsContext";
+
+import {
+  TEMPERATURE_UNITS,
+  WIND_UNITS,
+  PRECIPITATION_UNITS,
+} from "../../types/settingContextTypes";
+
+import type {
+  WindUnits,
+  TemperatureUnits,
+  PrecipitationUnits,
+} from "../../types/settingContextTypes";
+
+// Data for each UnitsDropdownGroup component.
+// Options are the unit values accepted by the API.
+// OptionsText are the values that will be displayed to the user.
 const dropdownData = {
   temperature: {
     title: "Temperature",
-    options: ["Celsius", "Fahrenheit"],
+    options: TEMPERATURE_UNITS,
     optionsText: ["Celsius (°C)", "Fahrenheit (°F)"],
   },
   windSpeed: {
     title: "Wind Speed",
-    options: ["km/h", "mph"],
+    options: WIND_UNITS,
     optionsText: ["km/h", "mph"],
   },
   precipitation: {
     title: "Precipitation",
-    options: ["mm", "in"],
+    options: PRECIPITATION_UNITS,
     optionsText: ["Millimeters (mm)", "inches (in)"],
   },
 };
@@ -29,52 +45,25 @@ interface IUnitsDropdownProps {
   ref: RefObject<HTMLDivElement | null>;
 }
 
+/**
+ * A component that renders a dropdown for selecting units.
+ * The component takes in a ref which is passed to the outermost div element.
+ * The currently selected option for each unit is highlighted with a background color.
+ */
 const UnitsDropdown = ({ ref }: IUnitsDropdownProps) => {
-  const [system, setSystem] = useState("Metric");
-  const [temperature, setTemperature] = useState("Celsius");
-  const [windSpeed, setWindSpeed] = useState("km/h");
-  const [precipitation, setPrecipitation] = useState("mm");
+  const {
+    system,
+    temperatureUnits,
+    windUnits,
+    precipitationUnits,
+    setTemperatureUnits,
+    setWindUnits,
+    setPrecipitationUnits,
+    handleSystemChange,
+  } = useSettingsContext();
 
-  const buttonText = system === "Metric" ? "Imperial" : "Metric";
-
-  const handleSystemChange = () => {
-    if (system === "Metric") {
-      setAllToImperial();
-    } else {
-      setAllToMetric();
-    }
-  };
-
-  const setAllToMetric = () => {
-    setSystem("Metric");
-    setTemperature("Celsius");
-    setWindSpeed("km/h");
-    setPrecipitation("mm");
-  };
-
-  const setAllToImperial = () => {
-    setSystem("Imperial");
-    setTemperature("Fahrenheit");
-    setWindSpeed("mph");
-    setPrecipitation("in");
-  };
-
-  // Sets the system state if all of the units are of the same system.
-  useEffect(() => {
-    if (
-      temperature === "Celsius" &&
-      windSpeed === "km/h" &&
-      precipitation === "mm"
-    ) {
-      setSystem("Metric");
-    } else if (
-      temperature === "Fahrenheit" &&
-      windSpeed === "mph" &&
-      precipitation === "in"
-    ) {
-      setSystem("Imperial");
-    }
-  }, [temperature, windSpeed, precipitation]);
+  // Displays the system state of the opposite of the current system.
+  const switchToSystem = system === "Metric" ? "Imperial" : "Metric";
 
   return (
     <div
@@ -85,40 +74,40 @@ const UnitsDropdown = ({ ref }: IUnitsDropdownProps) => {
         onClick={handleSystemChange}
         className="text-preset-7 text-neutral-0 py-2.5 px-2 hover:bg-neutral-700 w-full text-left rounded-lg hover:cursor-pointer"
       >
-        Switch to {buttonText}
+        Switch to {switchToSystem}
       </button>
 
       <Separator />
 
       {/* Temperature */}
-      <UnitsDropdownGroup
+      <UnitsDropdownGroup<TemperatureUnits>
         title={dropdownData.temperature.title}
         options={dropdownData.temperature.options}
         optionsText={dropdownData.temperature.optionsText}
-        action={setTemperature}
-        selected={temperature}
+        action={setTemperatureUnits}
+        selected={temperatureUnits}
       />
 
       <Separator />
 
       {/* Wind Speed */}
-      <UnitsDropdownGroup
+      <UnitsDropdownGroup<WindUnits>
         title={dropdownData.windSpeed.title}
         options={dropdownData.windSpeed.options}
         optionsText={dropdownData.windSpeed.optionsText}
-        action={setWindSpeed}
-        selected={windSpeed}
+        action={setWindUnits}
+        selected={windUnits}
       />
 
       <Separator />
 
       {/* Precipitation */}
-      <UnitsDropdownGroup
+      <UnitsDropdownGroup<PrecipitationUnits>
         title={dropdownData.precipitation.title}
         options={dropdownData.precipitation.options}
         optionsText={dropdownData.precipitation.optionsText}
-        action={setPrecipitation}
-        selected={precipitation}
+        action={setPrecipitationUnits}
+        selected={precipitationUnits}
       />
     </div>
   );

--- a/src/components/UnitsDropdownGroup/UnitsDropdownGroup.tsx
+++ b/src/components/UnitsDropdownGroup/UnitsDropdownGroup.tsx
@@ -1,21 +1,39 @@
 import type { Dispatch, SetStateAction } from "react";
 import { CheckIcon } from "../../assets/icons/pageIcons";
 
-interface IUnitsDropdownGroupProps {
+// Props for the UnitsDropdownGroup component.
+// The generic type parameter <T> is used to specify the type of the action.
+// readonly is used to assert that an immutable array is passed to resolve type errors.
+interface IUnitsDropdownGroupProps<T> {
   title: string;
-  options: string[];
-  optionsText: string[];
-  action: Dispatch<SetStateAction<string>>;
+  options: readonly string[];
+  optionsText: readonly string[];
+  action: Dispatch<SetStateAction<T>>;
   selected: string;
 }
 
-const UnitsDropdownGroup = ({
+/**
+ * A component that renders a dropdown group for selecting units.
+ * The component takes in a title, an array of options, an array of option texts,
+ * a radio button with a corresponding label.
+ * The currently selected option is highlighted with a background color.
+ *
+ * The <T,> is a generic type parameter where the comma is used to prevent TypeScript
+ * from interpretting the generic as an array or something else.
+ *
+ * @param {string} title - The title of the dropdown group.
+ * @param {string[]} options - An array of options to render.
+ * @param {string[]} optionsText - An array of text to render for each option.
+ * @param {Dispatch<SetStateAction<T>>} action - The action to dispatch when an option is selected.
+ * @param {string} selected - The currently selected option.
+ */
+const UnitsDropdownGroup = <T,>({
   title,
   options,
   optionsText,
   action,
   selected,
-}: IUnitsDropdownGroupProps) => {
+}: IUnitsDropdownGroupProps<T>) => {
   return (
     <div className="flex flex-col w-full">
       <div className="text-preset-8 text-neutral-300 py-1.5 px-2 pb-2">
@@ -36,7 +54,7 @@ const UnitsDropdownGroup = ({
                 name={title}
                 value={option}
                 checked={option === selected}
-                onChange={() => action(option)}
+                onChange={() => action(option as T)}
                 className="hidden"
               />
               {option === selected && <CheckIcon />}

--- a/src/context/SettingsContext/SettingsContext.ts
+++ b/src/context/SettingsContext/SettingsContext.ts
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+
+import type { ISettingsContextProps } from "../../types/settingContextTypes";
+
+export const SettingsContext = createContext<ISettingsContextProps | undefined>(
+  undefined
+);

--- a/src/context/SettingsContext/SettingsProvider.tsx
+++ b/src/context/SettingsContext/SettingsProvider.tsx
@@ -1,0 +1,78 @@
+import { useState, useEffect } from "react";
+import type { ReactNode } from "react";
+import { SettingsContext } from "./SettingsContext";
+
+import type {
+  System,
+  WindUnits,
+  TemperatureUnits,
+  PrecipitationUnits,
+} from "../../types/settingContextTypes";
+
+interface ISettingsProviderProps {
+  children: ReactNode;
+}
+
+export const SettingsProvider = ({ children }: ISettingsProviderProps) => {
+  const [system, setSystem] = useState<System>("Metric");
+  const [windUnits, setWindUnits] = useState<WindUnits>("kmh");
+  const [temperatureUnits, setTemperatureUnits] =
+    useState<TemperatureUnits>("Celsius");
+  const [precipitationUnits, setPrecipitationUnits] =
+    useState<PrecipitationUnits>("mm");
+
+  const setAllToImperial = () => {
+    setWindUnits("mph");
+    setTemperatureUnits("Fahrenheit");
+    setPrecipitationUnits("in");
+  };
+
+  const setAllToMetric = () => {
+    setWindUnits("kmh");
+    setTemperatureUnits("Celsius");
+    setPrecipitationUnits("mm");
+  };
+
+  const handleSystemChange = () => {
+    if (system === "Metric") {
+      setAllToImperial();
+    } else {
+      setAllToMetric();
+    }
+  };
+
+  // Changes the System state if all of the units are of the same system.
+  useEffect(() => {
+    if (
+      temperatureUnits === "Celsius" &&
+      windUnits === "kmh" &&
+      precipitationUnits === "mm"
+    ) {
+      setSystem("Metric");
+    } else if (
+      temperatureUnits === "Fahrenheit" &&
+      windUnits === "mph" &&
+      precipitationUnits === "in"
+    ) {
+      setSystem("Imperial");
+    }
+  }, [temperatureUnits, windUnits, precipitationUnits, setSystem]);
+
+  return (
+    <SettingsContext.Provider
+      value={{
+        system,
+        setSystem,
+        windUnits,
+        setWindUnits,
+        temperatureUnits,
+        setTemperatureUnits,
+        precipitationUnits,
+        setPrecipitationUnits,
+        handleSystemChange,
+      }}
+    >
+      {children}
+    </SettingsContext.Provider>
+  );
+};

--- a/src/hooks/useSettingsContext.tsx
+++ b/src/hooks/useSettingsContext.tsx
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+import { SettingsContext } from "../context/SettingsContext/SettingsContext";
+
+export const useSettingsContext = () => {
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error(
+      "useSettingsContext must be used within a SettingsProvider"
+    );
+  }
+
+  return context;
+};

--- a/src/types/settingContextTypes.ts
+++ b/src/types/settingContextTypes.ts
@@ -1,0 +1,29 @@
+import type { Dispatch, SetStateAction } from "react";
+
+export const SYSTEM = ["Metric", "Imperial"] as const;
+export type System = (typeof SYSTEM)[number];
+
+export const WIND_UNITS = ["kmh", "mph"] as const;
+export type WindUnits = (typeof WIND_UNITS)[number];
+
+export const TEMPERATURE_UNITS = ["Celsius", "Fahrenheit"] as const;
+export type TemperatureUnits = (typeof TEMPERATURE_UNITS)[number];
+
+export const PRECIPITATION_UNITS = ["mm", "in"] as const;
+export type PrecipitationUnits = (typeof PRECIPITATION_UNITS)[number];
+
+export interface ISettingsContextProps {
+  system: System;
+  setSystem: Dispatch<SetStateAction<System>>;
+
+  windUnits: WindUnits;
+  setWindUnits: Dispatch<SetStateAction<WindUnits>>;
+
+  temperatureUnits: TemperatureUnits;
+  setTemperatureUnits: Dispatch<SetStateAction<TemperatureUnits>>;
+
+  precipitationUnits: PrecipitationUnits;
+  setPrecipitationUnits: Dispatch<SetStateAction<PrecipitationUnits>>;
+
+  handleSystemChange: () => void;
+}


### PR DESCRIPTION
## Description
Creating a SettingsContext and a custom hook to easily use it. SettingsContext initially holds unit settings for...
- System
- Wind units
- Temperature units
- Precipitation units

Context also contains handler functions for changing unit states.
A types file for the context was created that can be easily expanded to include more units or settings.

Closes #31 
